### PR TITLE
Google Image Search API廃止に伴ってGoogle Custom Search APIを利用するように修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.0
+* Use Google Custom Search API instead of Google Image Search API
+
 ## 0.0.7
 * Rename: Ellen -> Ruboty
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,18 @@ An ruboty handler to search images from Google.
 
 ## Install
 
-This gem needs two enviroment variables.
+This gem needs two environment variables.
 
 - GOOGLE_CSE_ID
 - GOOGLE_CSE_KEY
+
+### CSE setup
+
+1. Create a CSE via these [instructions](https://developers.google.com/custom-search/docs/tutorial/creatingcse).
+1. Turn on images in Edit Search Engine > Setup > Basic > Image Search
+1. Get the CSE ID in Edit Search Engine > Setup > Basic > Details (via [these instructions](https://support.google.com/customsearch/answer/2649143?hl=en))
+1. Get the CSE KEY [here](https://code.google.com/apis/console)
+1. Update your env
 
 ## Usage
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Ruboty::GoogleImage
 An ruboty handler to search images from Google.
 
+## Install
+
+This gem needs two enviroment variables.
+
+- GOOGLE_CSE_ID
+- GOOGLE_CSE_KEY
+
 ## Usage
 ```
 @ruboty image <keyword> - Search image from Google

--- a/lib/ruboty/google_image/client.rb
+++ b/lib/ruboty/google_image/client.rb
@@ -30,7 +30,7 @@ module Ruboty
       end
 
       def response
-        connection.get(url, params).tap { |e| puts e.inspect }
+        connection.get(url, params)
       end
 
       def url

--- a/lib/ruboty/google_image/client.rb
+++ b/lib/ruboty/google_image/client.rb
@@ -13,7 +13,7 @@ module Ruboty
       end
 
       def get
-        resource["unescapedUrl"] if resource
+        resource["link"] if resource
       rescue => exception
         Ruboty.logger.error("Error: #{self}##{__method__} - #{exception}")
         nil
@@ -23,10 +23,8 @@ module Ruboty
 
       def resource
         @resource ||= begin
-          if data = response.body["responseData"]
-            if results = data["results"]
-              results.sample
-            end
+          if items = response.body["items"]
+            items.sample
           end
         end
       end

--- a/lib/ruboty/google_image/client.rb
+++ b/lib/ruboty/google_image/client.rb
@@ -4,7 +4,7 @@ require "faraday_middleware"
 module Ruboty
   module GoogleImage
     class Client
-      GOOGLE_IMAGE_API_URL = "http://ajax.googleapis.com/ajax/services/search/images"
+      GOOGLE_IMAGE_API_URL = "https://www.googleapis.com/customsearch/v1"
 
       attr_reader :options
 
@@ -32,7 +32,7 @@ module Ruboty
       end
 
       def response
-        connection.get(url, params)
+        connection.get(url, params).tap { |e| puts e.inspect }
       end
 
       def url
@@ -51,9 +51,11 @@ module Ruboty
 
       def default_params
         {
-          rsz: 8,
-          safe: "active",
-          v: "1.0",
+          searchType: 'image',
+          safe: 'high',
+          fields: 'items(link)',
+          cx: ENV['GOOGLE_CSE_ID'],
+          key: ENV['GOOGLE_CSE_KEY']
         }
       end
 

--- a/lib/ruboty/google_image/version.rb
+++ b/lib/ruboty/google_image/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module GoogleImage
-    VERSION = "0.0.7"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
先日からruboty-google_imageがうまく動かないようだったので修正しました。
原因はAPIの廃止と思われます。
GoogleImageSearchAPIからGoogleCustomSearchAPIに変更したら動くようになりました。
deprecatedであることのソースは[こちら](https://developers.google.com/image-search/?hl=ja)です。

hubot-google-imagesの以下のコミットに相当します。
https://github.com/hubot-scripts/hubot-google-images/commit/417a1eb262e035c676e4a01140c2e2d1b36f5f87

なおCSEの設定手順についてはこちらも参考にしました。
http://shirakiya.hatenablog.com/entry/2015/12/07/012906
