### PR TITLE
Fix broken this gem

### DIFF
--- a/lib/ruboty/google_image/client.rb
+++ b/lib/ruboty/google_image/client.rb
@@ -59,8 +59,8 @@ module Ruboty
 
       def connection
         Faraday.new do |connection|
-          connection.adapter :net_http
           connection.response :json
+          connection.adapter :net_http
         end
       end
     end


### PR DESCRIPTION
I got the failure of `@bot image ...` . And I've got the following warning. 

> WARNING: Unexpected middleware set after the adapter. This won't be supported from Faraday 1.0. 

I guess it's related the following Issues;

* https://github.com/r7kamura/rapa/issues/4
    * https://github.com/lostisland/faraday/pull/685

However, I've not checked if this change is correct.